### PR TITLE
Syntax fix

### DIFF
--- a/styles/setup.css
+++ b/styles/setup.css
@@ -35,7 +35,7 @@ svg {
 }
 
 
-// selects for custom elements
+/* selects for custom elements */
 :where(:not(:defined)) {
 	display: block;
 }


### PR DESCRIPTION
Change comment to CSS syntax instead of JS, to avoid triggering warning message